### PR TITLE
Updated version to 4.4.2

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -8,7 +8,7 @@ const add = async function (context) {
   const { ignite } = context
 
   // install a npm module
-  await ignite.addModule(NPM_MODULE_NAME, { version: '4.3.0', link: true })
+  await ignite.addModule(NPM_MODULE_NAME, { version: '4.4.2', link: true })
 
   // copy the example file (if examples are turned on)
   await ignite.addPluginComponentExample(EXAMPLE_FILE, { title: 'Vector Icons' })

--- a/test/add.test.js
+++ b/test/add.test.js
@@ -14,7 +14,7 @@ test('adds itself', async t => {
   }
 
   await plugin.add(context)
-  t.true(addModule.calledWith('react-native-vector-icons', { version: '4.3.0', link: true }))
+  t.true(addModule.calledWith('react-native-vector-icons', { version: '4.4.2', link: true }))
   t.true(
     addPluginComponentExample.calledWith('vectorExample.js.ejs', {
       title: 'Vector Icons'


### PR DESCRIPTION
I was using this plugin with the `elements` plugin and the elements plugin makes use of the Feather font from vector-icons but 4.3.0 doesn't have that font. Therefore, the elements plugin would be broken for everyone until this gets merged.