### PR TITLE
version update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 npm-debug.log*
 .nyc_output
 coverage
+.idea

--- a/plugin.js
+++ b/plugin.js
@@ -8,7 +8,7 @@ const add = async function (context) {
   const { ignite } = context
 
   // install a npm module
-  await ignite.addModule(NPM_MODULE_NAME, { version: '4.4.2', link: true })
+  await ignite.addModule(NPM_MODULE_NAME, { version: '6.1.0', link: true })
 
   // copy the example file (if examples are turned on)
   await ignite.addPluginComponentExample(EXAMPLE_FILE, { title: 'Vector Icons' })


### PR DESCRIPTION
the old version have build error on android

```
Error:Could not find any matches for com.android.tools.build:gradle:2.3.+ as no versions of com.android.tools.build:gradle are available.
Searched in the following locations:
    https://jcenter.bintray.com/com/android/tools/build/gradle/maven-metadata.xml
    https://jcenter.bintray.com/com/android/tools/build/gradle/
Required by:
    project :react-native-vector-icons
```

